### PR TITLE
Fix for nocontrol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ results/
 result/
 results2/
 results37/
+results_vep/
+results_annovar/
 test.xml
 test_output/
 tests/data/
@@ -21,3 +23,4 @@ testdata_hg37/
 .github/CODEOWNERS-tmp
 bin/vcfparser.pyc
 singularity/
+snvs_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,3 +70,12 @@ Initial release of ghga-de/nf-snvcalling, created with the [nf-core](https://nf-
 
 ### `Added`
  - nf-prov plugin is added.
+
+## v2.0.2 - 12.11.2024
+
+### `Fixed`
+- add cram/crai files to input list (assets/schema_input.json)
+- add only a warn about the indices does not exists in converttovcf.json (bin/convertToStdVCF.py)
+- change default arg for ENSEMBL VEP (conf/modules.config)
+- upgrade samtools version for cram handling (modules/local/grep_samplename.nf)
+- edit nextflow version to latest (nextflow.config)

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -14,15 +14,33 @@
       },
       "tumor": {
         "type": "string",
-        "pattern": "^\\S+\\.bam$",
-        "errorMessage": "BAM file for tumors must be provided'"
+        "pattern": "^\\S+\\.(bam|cram)$",
+        "errorMessage": "BAM or CRAM file for tumors must be provided'"
+      },
+      "tumor_index": {
+        "type": "string",
+        "pattern": "^\\S+\\.(bai|crai)$",
+        "errorMessage": "BAI OR crai file matching to BAM for tumors must be provided'"
       },
       "control": {
-        "errorMessage": "BAM file for as control matching to tumor, if there is",
+        "errorMessage": "BAM or CRAM file for as control matching to tumor, if there is",
         "anyOf": [
           {
             "type": "string",
-            "pattern": "^\\S+\\.bam$"
+            "pattern": "^\\S+\\.(bam|cram)$"
+          },
+          {
+            "type": "string",
+            "maxLength": 0
+          }
+        ]
+      },
+      "control_index": {
+        "errorMessage": "BAI or CRAI file matching to BAM for as control matching to tumor, if there is",
+        "anyOf": [
+          {
+            "type": "string",
+            "pattern": "^\\S+\\.(bai|crai)$"
           },
           {
             "type": "string",
@@ -31,6 +49,6 @@
         ]
       }
     },
-    "required": ["sample", "tumor"]
+    "required": ["sample", "tumor", "tumor_index"]
   }
 }

--- a/bin/convertToStdVCF.py
+++ b/bin/convertToStdVCF.py
@@ -276,8 +276,16 @@ def extract_freestanding_columns_into_dict(line_original, col_indices, meta_info
     ]
 
     cols_as_INFO_dict = {}
+    
     for column_name in columns_to_extract:
         if column_name not in col_indices:
+            print("Warning: '{}' not found in column indices.".format(column_name))
+            continue
+
+        column_index = col_indices[column_name]
+
+        if column_index >= len(line_original):
+            print("Warning: Column '{}' index {} is out of bounds in line: {}".format(column_name, column_index, line_original))
             continue
 
         old_column_contents = line_original[col_indices[column_name]]
@@ -548,4 +556,4 @@ if __name__ == '__main__':
         header =False
     else:
         header = args.raw_vcf      
-    convert(args.input_file, args.output_file, args.sample_id, meta_information,args.withcontrol,header)
+    convert(args.input_file, args.output_file, args.sample_id, meta_information, args.withcontrol, header)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -166,7 +166,7 @@ process {
         ]
     }
     withName: 'ENSEMBLVEP_VEP' {
-        ext.args         ='--everything --filter_common --per_gene --total_length --offline'
+        ext.args         ='--everything --total_length --offline'
         publishDir       = [
             [
                 mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -166,7 +166,7 @@ process {
         ]
     }
     withName: 'ENSEMBLVEP_VEP' {
-        //ext.args         ='--everything --filter_common --per_gene --total_length --offline'
+        ext.args         ='--everything --filter_common --per_gene --total_length --offline'
         publishDir       = [
             [
                 mode: params.publish_dir_mode,

--- a/conf/test.config
+++ b/conf/test.config
@@ -96,7 +96,7 @@ process {
         memory          = { check_max( 12.GB * task.attempt, 'memory' ) }
    }
     // using vep online is only recommended for test purposes for a minimal set of variants!
-    withName: 'ENSEMBLVEP_VEP' {
+    withName: 'NF_SNVCALLING:SNVCALLING:SNV_ANNOTATION:ENSEMBLVEP_VEP' {
         ext.args         ='--per_gene --total_length'
     }
 }

--- a/modules/local/grep_samplename.nf
+++ b/modules/local/grep_samplename.nf
@@ -4,7 +4,7 @@ process GREP_SAMPLENAME {
 
     conda (params.enable_conda ? "" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://kubran/odcf_mpileupsnvcalling:v0':'kubran/odcf_mpileupsnvcalling:v0' }"
+        'docker://kubran/samtools:v1.9':'kubran/samtools:v1.9' }"
 
     input:
     tuple val(meta), path(tumor), path(tumor_bai), path(control),  path(control_bai)
@@ -20,8 +20,8 @@ process GREP_SAMPLENAME {
     if (meta.iscontrol == '1')
     {
         """
-        controlname=`samtools view -H $meta.control_bam | grep '^@RG' | sed "s/.*SM:\\([^\\t]*\\).*/\\1/g" | uniq`
-        tumorname=`samtools view -H $meta.tumor_bam | grep '^@RG' | sed "s/.*SM:\\([^\\t]*\\).*/\\1/g" | uniq`
+        controlname=`samtools view -H $control | grep '^@RG' | sed "s/.*SM:\\([^\\t]*\\).*/\\1/g" | uniq`
+        tumorname=`samtools view -H $tumor | grep '^@RG' | sed "s/.*SM:\\([^\\t]*\\).*/\\1/g" | uniq`
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -33,7 +33,7 @@ process GREP_SAMPLENAME {
     else {
         """
         controlname='dummy'
-        tumorname=`samtools view -H $meta.tumor_bam | grep '^@RG' | sed "s/.*SM:\\([^\\t]*\\).*/\\1/g" | uniq`
+        tumorname=`samtools view -H $tumor | grep '^@RG' | sed "s/.*SM:\\([^\\t]*\\).*/\\1/g" | uniq`
         
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -294,8 +294,8 @@ manifest {
     homePage        = 'https://github.com/kubranarci/nf-snvcalling'
     description     = 'ODCF SNV Calling pipeline'
     mainScript      = 'main.nf'
-    nextflowVersion = '!>=23.10.3'
-    version         = '2.0.1'
+    nextflowVersion = '!>=23.10.1'
+    version         = '2.0.2'
 }
 // Nextflow plugins
 plugins {

--- a/nextflow.config
+++ b/nextflow.config
@@ -82,6 +82,11 @@ params {
     cytobandcol                = '"CYTOBAND"'              // default value
     geneannocols               = '"ANNOVAR_FUNCTION,GENE,EXONIC_CLASSIFICATION,ANNOVAR_TRANSCRIPTS"' // default value
 
+    // VEP
+    vep_cache_version          = null
+    vep_genome                 = null
+    vep_cache                  = null
+    download_cache             = true  // DO NOT Download annotation cache
 
     // Files //
     data_path                  = null          // If database files in the same place 


### PR DESCRIPTION
- add cram/crai files to input list (assets/schema_input.json)
- add only a warn about the indices does not exists in converttovcf.json (bin/convertToStdVCF.py)
- change default arg for ENSEMBL VEP (conf/modules.config)
- upgrade samtools version for cram handling (modules/local/grep_samplename.nf)
- edit nextflow version to latest (nextflow.config)